### PR TITLE
Fixes #78 Use full keys with rocksdb

### DIFF
--- a/src/UI/Shared/MainLayout.razor
+++ b/src/UI/Shared/MainLayout.razor
@@ -38,7 +38,7 @@
         </Stack>
 
         <ResponsiveLayout MaxWidth="ResponsiveMode.Medium.ToMaxCssValue()">
-            <Panel Type=@PanelType.SmallFixedNear OnDismiss=@(new EventCallback(this, (Action<bool>)((b) => isPanelOpen = false))) IsOpen="@isPanelOpen" IsLightDismiss="true">
+            <Panel Type=@PanelType.SmallFixedNear OnDismiss=@(b => isPanelOpen = false) IsOpen="@isPanelOpen" IsLightDismiss="true">
                 <NavigationTemplate>
                     <IconButton IconName="GlobalNavButton" OnClick="@(() => isPanelOpen = false)" />
                     <Link Href="https://github.com/astn/ahghee" Target="_blank">on GitHub</Link>

--- a/src/benchmark/Program.cs
+++ b/src/benchmark/Program.cs
@@ -218,9 +218,15 @@ namespace benchmark
 
 
         [Benchmark(Baseline = true)]
-        public int StringHash()
+        public int StringHash32()
         {
             return nid.Remote.GetHashCode() ^ nid.Iri.GetHashCode();
+        }
+
+        [Benchmark()]
+        public long StringHash64()
+        {
+            return (((long)nid.Remote.GetHashCode()) << 32) ^ nid.Iri.GetHashCode();
         }
         
         [Benchmark()]
@@ -230,9 +236,20 @@ namespace benchmark
         }
       
         [Benchmark()]
-        public int MurmurHash()
+        public long MurmurHash()
         {
             return nid.GetHashCodeGoodDistribution(nid);
+        }
+        
+        [Benchmark()]
+        public long GetBytesForKey()
+        {
+            unsafe
+            {
+                Span<byte> bytes = stackalloc byte[nid.GetKeyBytesSize()];
+                nid.WriteKeyBytes(bytes);
+                return bytes.Length;
+            }
         }
         
     }
@@ -299,7 +316,8 @@ namespace benchmark
     {
         static void Main(string[] args)
         {
-            var summary4 = BenchmarkRunner.Run<WriteNodesBenchmark>();
+            var AddNodesBench = BenchmarkRunner.Run<NodeIdHashBench>();
+            //var summary4 = BenchmarkRunner.Run<WriteNodesBenchmark>();
             //var summary0 = BenchmarkRunner.Run<CreatingTypes>();
             //var summary1 = BenchmarkRunner.Run<CreatingKeyValue>();
             //var summary2 = BenchmarkRunner.Run<CreatingNodeEmpty>();

--- a/src/benchmark/benchmark.csproj
+++ b/src/benchmark/benchmark.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />

--- a/src/cli-grammer/NTRIPLES.g4
+++ b/src/cli-grammer/NTRIPLES.g4
@@ -102,7 +102,9 @@ fragment EXP
    : [Ee] [+\-]? INT
    ;
 
-fragment COMMENT : '#' .*?  -> skip;
+COMMENT 
+    : (' #' | '.#' ) .*?  -> skip
+    ;
    
 WS
    : [ \t\r\n] + -> skip

--- a/src/core.tests/Tests.fs
+++ b/src/core.tests/Tests.fs
@@ -232,7 +232,7 @@ type MyTests(output:ITestOutputHelper) =
     [<Theory>]
     [<InlineData("StorageType.Memory")>]
     [<InlineData("StorageType.GrpcFile")>] 
-    member __.``Can get IDs after load tinkerpop-crew.xml into graph`` storeType =
+    member __.``Can get IDs after load tinkercrew into graph`` storeType =
          let g = 
              match storeType with 
              | "StorageType.Memory" ->   new MemoryStore() :> IStorage
@@ -419,7 +419,7 @@ type MyTests(output:ITestOutputHelper) =
     [<Theory>]
     [<InlineData("mem")>]
     [<InlineData("file")>]
-    member __.``Can get labelV after load tinkerpop-crew.xml into graph`` db =
+    member __.``Can get labelV after load tinkercrew into graph`` db =
          let g = __.toyGraph (dbtype db)
                   
          output.WriteLine("g.Nodes length: {0}", g.Nodes() |> Seq.length )
@@ -445,7 +445,7 @@ type MyTests(output:ITestOutputHelper) =
     [<Theory>]
     [<InlineData("mem")>]
     [<InlineData("file")>] 
-    member __.``After load tinkerpop-crew.xml Age has meta type int and comes out as int`` db =
+    member __.``After load tinkercrew Age has meta type int and comes out as int`` db =
          let g = __.toyGraph (dbtype db)
                   
          output.WriteLine("g.Nodes length: {0}", g.Nodes() |> Seq.length )
@@ -470,7 +470,7 @@ type MyTests(output:ITestOutputHelper) =
     [<InlineData("file", 0)>]
     [<InlineData("file", 1)>]
     [<InlineData("file", 2)>]
-    member __.``After load tinkerpop-crew.xml multiple flush do not destroy data`` db flushes =
+    member __.``After load tinkercrew multiple flush do not destroy data`` db flushes =
          let g = __.toyGraph (dbtype db)
          
          for i in 0 .. flushes do
@@ -498,7 +498,7 @@ type MyTests(output:ITestOutputHelper) =
     [<InlineData("file", 0)>]
     [<InlineData("file", 1)>]
     [<InlineData("file", 2)>]
-    member __.``After load tinkerpop-crew.xml multiple adds do not destroy data`` db flushes =
+    member __.``After load tinkercrew multiple adds do not destroy data`` db flushes =
          let g = __.toyGraph (dbtype db)
          
          for i in 0 .. flushes do
@@ -522,7 +522,7 @@ type MyTests(output:ITestOutputHelper) =
     [<Theory>]
     [<InlineData("mem")>]
     [<InlineData("file")>]  
-    member __.``After load tinkerpop-crew.xml Nodes have 'out.knows' Edges`` db =
+    member __.``After load tinkercrew Nodes have 'out.knows' Edges`` db =
         let g = __.toyGraph (dbtype db)
               
         let attrName = "out.knows"
@@ -542,7 +542,7 @@ type MyTests(output:ITestOutputHelper) =
     [<Theory>]
     [<InlineData("mem")>]
     [<InlineData("file")>] 
-    member __.``After load tinkerpop-crew.xml Nodes have 'out.created' Edges`` db =        
+    member __.``After load tinkercrew Nodes have 'out.created' Edges`` db =        
         let g = __.toyGraph (dbtype db)
         let attrName = "out.created"
         let actual = __.CollectValues attrName g                                         
@@ -562,7 +562,7 @@ type MyTests(output:ITestOutputHelper) =
     [<Theory>]
     [<InlineData("mem")>]
     [<InlineData("file")>] 
-    member __.``After load tinkerpop-crew.xml Nodes have 'in.knows' Edges`` db =
+    member __.``After load tinkercrew Nodes have 'in.knows' Edges`` db =
         let g = __.toyGraph (dbtype db)
               
         let attrName = "in.knows"
@@ -580,7 +580,7 @@ type MyTests(output:ITestOutputHelper) =
     [<Theory>]
     [<InlineData("mem")>]
     [<InlineData("file")>] 
-    member __.``After load tinkerpop-crew.xml Nodes have 'in.created' Edges`` db =        
+    member __.``After load tinkercrew Nodes have 'in.created' Edges`` db =        
         let sortedByNodeIdEdgeId (data: list<string * string * TMD>) = 
             data 
             |> List.sortBy (fun (a,b,c) -> 
@@ -609,7 +609,7 @@ type MyTests(output:ITestOutputHelper) =
     [<Theory>]
     [<InlineData("mem")>]
     [<InlineData("file")>] 
-    member __.``After load tinkerpop-crew.xml has Edge-nodes`` db =        
+    member __.``After load tinkercrew has Edge-nodes`` db =        
         let g = __.toyGraph (dbtype db)
         let attrName = "labelE"
         let actual = __.CollectValues attrName g                                       
@@ -631,7 +631,7 @@ type MyTests(output:ITestOutputHelper) =
     [<Theory>]
     [<InlineData("mem")>]
     [<InlineData("file")>] 
-    member __.``After load tinkerpop-crew.xml has node data`` db =        
+    member __.``After load tinkercrew has node data`` db =        
         let g = __.toyGraph (dbtype db)
         output.WriteLine(sprintf "%A" (g.Nodes()))
         Assert.NotEmpty(g.Nodes())

--- a/src/core/MemoryStore.fs
+++ b/src/core/MemoryStore.fs
@@ -26,12 +26,12 @@ type MemoryStore() =
             
         member this.Items (addresses:seq<NodeID>, follow: Step) =
             let matches = addresses |> Seq.map (fun addr -> 
-                                                        let isLocal = _nodes 
-                                                                      |> Seq.tryFind ( fun n -> n.Id = addr)
-                                                        let found = match isLocal with
-                                                            | Some(n) -> Either<Node,Exception>(n)
-                                                            | _ -> Either<Node,Exception>(new Exception("Not Found"))
-                                                        struct (addr, found)
+                        let isLocal = _nodes 
+                                      |> Seq.tryFind ( fun n -> n.Id = addr)
+                        let found = match isLocal with
+                                        | Some(n) -> Either<Node,Exception>(n)
+                                        | _ -> Either<Node,Exception>(new Exception("Not Found"))
+                        struct (addr, found)
                                                                 
                                                 )
             Task.FromResult matches      

--- a/src/core/Types.fs
+++ b/src/core/Types.fs
@@ -72,40 +72,37 @@ type NodeIdIndex (indexFile:string) =
 
     member __.Iter() =
         seq {
-            use mutable it = db.NewIterator()
-            it.SeekToFirst()
+            use mutable it = db.NewIterator().SeekToFirst() 
             while it.Valid() do
                 let repeatedField = new Pointers()
                 let bytes = it.Value()
                 let codedinputStream = new CodedInputStream(bytes,0,bytes.Length)
                 repeatedField.MergeFrom(codedinputStream)
                 yield repeatedField
-                it.Next()
+                it.Next() |> ignore
         }
     
     member __.IterKey() =
         seq {
-            use mutable it = db.NewIterator()
-            it.SeekToFirst()
+            use mutable it = db.NewIterator().SeekToFirst()
             while it.Valid() do
                 let repeatedField = new Pointers()
                 let bytes = it.Value()
                 yield bytes
-                it.Next()
+                it.Next() |> ignore
         }
         
 
     member __.IterKV() =
         seq {
-            use mutable it = db.NewIterator()
-            it.SeekToFirst()
+            use mutable it = db.NewIterator().SeekToFirst()
             while it.Valid() do
                 let repeatedField = new Pointers()
                 let bytes = it.Value()
                 let codedinputStream = new CodedInputStream(bytes,0,bytes.Length)
                 repeatedField.MergeFrom(codedinputStream)
                 yield (it.Key(), repeatedField)
-                it.Next()
+                it.Next() |> ignore
         }        
         
     

--- a/src/parser/ContextExtensions.cs
+++ b/src/parser/ContextExtensions.cs
@@ -1,10 +1,17 @@
 using System;
+using System.Buffers.Text;
+using System.IO;
 using System.Security.Principal;
+using System.Text;
 using Ahghee;
 using Ahghee.Grpc;
+using Antlr4.Runtime;
+using Antlr4.Runtime.Misc;
+using Antlr4.Runtime.Tree;
 using cli_grammer;
 using Google.Protobuf;
 using Range = Ahghee.Grpc.Range;
+using Utils = Ahghee.Grpc.Utils;
 
 namespace cli
 {
@@ -96,7 +103,7 @@ namespace cli
             var pred = ctx.GetText().Trim('<', '>');
             return pred.ToDataBlockNodeID();
         }
-        
+
         public static NodeID ToNodeId(this NTRIPLESParser.SubjContext ctx, Func<string,string> BNToId)
         {
             var subIRI = ctx.IRI()?.GetText()?.Trim('<', '>');

--- a/src/parser/Listener.cs
+++ b/src/parser/Listener.cs
@@ -42,22 +42,30 @@ namespace cli.antlr
         }
         public override void ExitTriple(NTRIPLESParser.TripleContext context)
         {
-            var nodeId = context.subj().ToNodeId(BNToId);
-
-            var pred = context.pred().ToDataBlock();
-
-            var obj = context.obj().ToDataBlock(BNToId);
-            var node = new Node();
-            node.Id = nodeId;
-            node.Attributes.Add(new KeyValue
+            try
             {
-                Key = new TMD
+                var nodeId = context.subj().ToNodeId(BNToId);
+
+                var pred = context.pred().ToDataBlock();
+
+                var obj = context.obj().ToDataBlock(BNToId);
+                var node = new Node();
+                node.Id = nodeId;
+                node.Attributes.Add(new KeyValue
                 {
-                    Data = pred,
-                },
-                Value = obj
-            });
-            _gotNode(node);
+                    Key = new TMD
+                    {
+                        Data = pred,
+                    },
+                    Value = obj
+                });
+                _gotNode(node);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Uh.. got this -->\n{context.GetText()}\n<-- Ends here");
+                throw;
+            }
         }
     }
     

--- a/src/server/Services/WatService.cs
+++ b/src/server/Services/WatService.cs
@@ -5,10 +5,12 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 using Ahghee;
 using Ahghee.Grpc;
 using Antlr4.Runtime;
+using cli;
 using cli.antlr;
 using cli_grammer;
 using Google.Protobuf.WellKnownTypes;
@@ -18,6 +20,7 @@ using Utils = Ahghee.Utils;
 
 namespace server
 {
+    
     public class WatService : Ahghee.Grpc.WatDbService.WatDbServiceBase
     {
         private readonly ILogger<WatService> _logger;
@@ -74,6 +77,79 @@ namespace server
             return cpuPercent;
         }
 
+        private async Task ParseNTStream(Stream data)
+        {
+            ConcurrentQueue<Node> batch = new ConcurrentQueue<Node>();
+
+            var parser = new NTRIPLESParser(makeNTRIPLESStream(data));
+            parser.BuildParseTree = true;
+
+            async Task GroupAndAdd(List<Node> list)
+            {
+                var nodes = list.GroupBy(n => n.Id, (key, ns) =>
+                {
+                    return new Node
+                    {
+                        Id = key,
+                        Attributes = {ns.SelectMany(_n => _n.Attributes)}
+                    };
+                });
+                await _db.Add(nodes.ToList());
+            }
+
+            parser.AddParseListener(new NtriplesListener(async (node) =>
+            {
+                batch.Enqueue(node);
+
+                // because we dealing with triples, we may get a bunch for the same nodeId
+                // do a little grouping to reduce the amount of fragments we create
+                if (batch.Count <= 600) return;
+                var mine = new List<Node>();
+                while (!batch.IsEmpty)
+                {
+                    if (batch.TryDequeue(out var nnnnnn))
+                    {
+                        mine.Add(nnnnnn);    
+                    }
+                }
+                
+                await GroupAndAdd(mine);
+            }));
+
+            parser.AddErrorListener(new ErrorListener());
+            NTRIPLESParser.TripleContext cc = null;
+
+            for (;; cc = parser.triple())
+            {
+                if (cc?.exception != null
+                    //&& cc.exception.GetType() != typeof(Antlr4.Runtime.InputMismatchException)
+                    //&& cc.exception.GetType() != typeof(Antlr4.Runtime.NoViableAltException)
+                )
+                {
+                    Console.WriteLine(cc.exception.Message);
+                    Console.WriteLine(
+                        $"found {cc.exception.OffendingToken.Text} at Line {cc.exception.OffendingToken.Line} offset at {cc.exception.OffendingToken.StartIndex}");
+                }
+                
+                if (parser.CurrentToken.Type == TokenConstants.Eof)
+                {
+                    break;
+                }
+            }
+            // deal with the remainder of the batch.
+            var mine2 = new List<Node>();
+            while (!batch.IsEmpty)
+            {
+                if (batch.TryDequeue(out var nnnnnn))
+                {
+                    mine2.Add(nnnnnn);    
+                }
+            }
+            if (mine2.Count > 0)
+            {
+                await GroupAndAdd(mine2);
+            }
+        }
 
         public override async Task<LoadFileResponse> Load(LoadFile request, ServerCallContext context)
         {
@@ -96,77 +172,63 @@ namespace server
                             data = File.OpenRead(request.Path);
                         }
                         await using var cleanup = data;
-                        ConcurrentQueue<Node> batch = new ConcurrentQueue<Node>();
-                        var sw = Stopwatch.StartNew();
-                        var parser = new NTRIPLESParser(makeNTRIPLESStream(data));
-                        parser.BuildParseTree = true;
-
-                        async Task GroupAndAdd(List<Node> list)
+                        await using var bs = new BufferedStream(data, 4096);
                         {
-                            var nodes = list.GroupBy(n => n.Id, (key, ns) =>
+                            long lastCopyPostition = 0;
+                            var lastNewLinePosition = 0;
+                            var unreadCount = 0L;
+                            var memory = new byte[81920];
+                            await using var mainView = new MemoryStream(memory);
+                            do
                             {
-                                return new Node
+                                var newBytesAdded = await bs.ReadAsync(memory, (int)unreadCount, (int)(memory.Length - unreadCount));
+                                lastCopyPostition = unreadCount + newBytesAdded;
+                                if (lastCopyPostition == 0)
+                                    break;
+                                // move back to beginning
+                                mainView.Seek(0, SeekOrigin.Begin);
+                                // find the last new line
+                                var tr = new StreamReader(mainView, Encoding.ASCII, true, -1, true);
+                                
+                                var lnlpcheck = 0;
+                                var lnlpcheckf =0;
+                                var slashcnt = 0;
+                                while (lnlpcheck <= lastCopyPostition )
                                 {
-                                    Id = key,
-                                    Attributes = {ns.SelectMany(_n => _n.Attributes)}
-                                };
-                            });
-                            await _db.Add(nodes.ToList());
-                        }
-
-                        parser.AddParseListener(new NtriplesListener(async (node) =>
-                        {
-                            batch.Enqueue(node);
-
-                            // because we dealing with triples, we may get a bunch for the same nodeId
-                            // do a little grouping to reduce the amount of fragments we create
-                            if (batch.Count <= 600) return;
-                            var mine = new List<Node>();
-                            while (!batch.IsEmpty)
-                            {
-                                if (batch.TryDequeue(out var nnnnnn))
-                                {
-                                    mine.Add(nnnnnn);    
+                                    lnlpcheck++;
+                                    var c = (char) tr.Read();
+                                    // if (c == '\\')
+                                    // {
+                                    //     slashcnt++;
+                                    // }
+                                    // else
+                                    // {
+                                    //     slashcnt = 0;
+                                    // }
+                                    // period is the statement terminator, not newline.
+                                    // if slashs before the . are odd then the dot is escaped.
+                                    // if we are inside a quote block though... we in trouble.
+                                    if (c == '\n' )//&& slashcnt % 1 == 0) 
+                                    {
+                                        lnlpcheckf = lnlpcheck;
+                                       // lastNewLinePosition = Convert.ToInt32(mainView.Position);    
+                                    }
                                 }
-                            }
-                            
-                            await GroupAndAdd(mine);
-                        }));
 
-                        parser.AddErrorListener(new ErrorListener());
-                        NTRIPLESParser.TripleContext cc = null;
+                                lastNewLinePosition = lnlpcheckf;
 
-                        for (;; cc = parser.triple())
-                        {
-                            if (cc?.exception != null
-                                //&& cc.exception.GetType() != typeof(Antlr4.Runtime.InputMismatchException)
-                                //&& cc.exception.GetType() != typeof(Antlr4.Runtime.NoViableAltException)
-                            )
-                            {
-                                Console.WriteLine(cc.exception.Message);
-                                Console.WriteLine(
-                                    $"found {cc.exception.OffendingToken.Text} at Line {cc.exception.OffendingToken.Line} offset at {cc.exception.OffendingToken.StartIndex}");
-                            }
-                            
-                            if (parser.CurrentToken.Type == TokenConstants.Eof)
-                            {
-                                break;
-                            }
+                                // create a vew up to that position;
+                                var pageView = new MemoryStream(memory, 0, lastNewLinePosition);
+
+                                // run the parser on that pageView.
+                                await ParseNTStream(pageView);
+                                // move the end of the stream that we didn't read back to the beginning
+                                unreadCount = lastCopyPostition - lastNewLinePosition;
+                                Buffer.BlockCopy(memory, lastNewLinePosition, memory, 0,
+                                    Convert.ToInt32(unreadCount));
+                                
+                            } while (lastCopyPostition > 0);
                         }
-                        // deal with the remainder of the batch.
-                        var mine2 = new List<Node>();
-                        while (!batch.IsEmpty)
-                        {
-                            if (batch.TryDequeue(out var nnnnnn))
-                            {
-                                mine2.Add(nnnnnn);    
-                            }
-                        }
-                        if (mine2.Count > 0)
-                        {
-                            await GroupAndAdd(mine2);
-                        }
-                       // _db.Flush();
                     }
                     catch (Exception e)
                     {

--- a/src/serverlib/WasmInterop.cs
+++ b/src/serverlib/WasmInterop.cs
@@ -29,7 +29,6 @@ namespace Ahghee.Grpc
             var host = new Wasmtime.Host();
             Called = false;
             // make a function available to wasm.
-            var initialValue = 1;
             var glob = host.DefineMutableGlobal<Int32>("", "global", 1);
             host.DefineFunction(
                 "",


### PR DESCRIPTION
When writing to rocksDb, we now write the whole node bytes minus the pointer.
Switched to using the native interface for the rocksdb.merge operation.
Fixed some test names, that were not running well in rider.

Fixed #78 